### PR TITLE
Add SoundHelper module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,50 @@ messageManager.sendMessage(this, player, "welcome-message",
     MessageManager.placeholders("player", player.getName(), "server", "MyServer"));
 ```
 
+### Sound Management
+- **Config-based sounds** - Load sounds from config with caching for performance
+- **Preset sounds** - Built-in `success`, `error`, `click`, `ding` presets configurable in YskLib's config
+- **Per-plugin pools** - Each plugin maintains its own sound registry
+- **Module sounds** - Organize sounds by feature/module within plugins
+- **Dual format support** - Compact (`SOUND:volume:pitch`) and verbose YAML formats
+
+Example usage:
+```java
+YskLib yskLib = (YskLib) getServer().getPluginManager().getPlugin("YskLib");
+SoundHelper soundHelper = yskLib.getSoundHelper();
+
+// Play preset sounds
+soundHelper.playSuccess(player);
+soundHelper.playError(player);
+soundHelper.playClick(player);
+
+// Load custom sounds from your plugin's config
+soundHelper.loadSounds(this, getConfig().getConfigurationSection("sounds"));
+
+// Play a loaded sound by key
+soundHelper.play(this, player, "reward");
+
+// Direct play without config
+soundHelper.play(player, Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.2f);
+```
+
+Config format:
+```yaml
+# In YskLib config.yml - preset customization
+modules:
+  sounds:
+    presets:
+      success: "ENTITY_PLAYER_LEVELUP:1.0:1.2"
+
+# In your plugin - custom sounds
+sounds:
+  reward: "ENTITY_PLAYER_LEVELUP:1.0:1.5"
+  deny:
+    sound: ENTITY_VILLAGER_NO
+    volume: 1.0
+    pitch: 0.8
+```
+
 ### World Management
 - `YskLib#canExecuteInWorld(JavaPlugin plugin, World world)` checks if a plugin is enabled in a specific world based on the `enabled-worlds` configuration list.
 - Supports wildcard `*` to enable all worlds.

--- a/src/main/java/org/yusaki/lib/YskLib.java
+++ b/src/main/java/org/yusaki/lib/YskLib.java
@@ -19,6 +19,7 @@ import org.yusaki.lib.modules.MessageManager;
 import org.yusaki.lib.modules.ItemEditManager;
 import org.yusaki.lib.modules.CustomItemManager;
 import org.yusaki.lib.modules.DialogService;
+import org.yusaki.lib.modules.SoundHelper;
 import org.yusaki.lib.text.ColorHelper;
 
 import io.sentry.Sentry;
@@ -35,6 +36,7 @@ public final class YskLib extends JavaPlugin {
     private ItemEditManager itemEditManager;
     private CustomItemManager customItemManager;
     private DialogService dialogService;
+    private SoundHelper soundHelper;
     private final Map<String, PluginInfo> sentryRegistry = new ConcurrentHashMap<>();
     private record PluginInfo(String name, String version, boolean consent) {}
 
@@ -79,6 +81,12 @@ public final class YskLib extends JavaPlugin {
         if (getConfig().getBoolean("modules.custom-items.enabled", true)) {
             customItemManager = new CustomItemManager(this);
             getLogger().info("CustomItemManager module enabled!");
+        }
+
+        // Initialize SoundHelper
+        if (getConfig().getBoolean("modules.sounds.enabled", true)) {
+            soundHelper = new SoundHelper(this);
+            getLogger().info("SoundHelper module enabled!");
         }
 
         initSentry();
@@ -462,5 +470,13 @@ public final class YskLib extends JavaPlugin {
 
     public DialogService getDialogService() {
         return dialogService;
+    }
+
+    /**
+     * Get the SoundHelper for playing sounds
+     * @return SoundHelper instance or null if not initialized
+     */
+    public SoundHelper getSoundHelper() {
+        return soundHelper;
     }
 }

--- a/src/main/java/org/yusaki/lib/modules/SoundHelper.java
+++ b/src/main/java/org/yusaki/lib/modules/SoundHelper.java
@@ -1,0 +1,237 @@
+package org.yusaki.lib.modules;
+
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.yusaki.lib.YskLib;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Sound helper module providing config-based sound loading with caching,
+ * preset sounds for common UI feedback, and per-plugin sound pools.
+ *
+ * Supports two config formats:
+ * - Compact: "SOUND_NAME:volume:pitch" (e.g., "ENTITY_PLAYER_LEVELUP:1.0:1.2")
+ * - Verbose: YAML map with sound, volume, pitch keys
+ */
+public class SoundHelper {
+
+    public record SoundEntry(Sound sound, float volume, float pitch) {
+        public void play(Player player) {
+            player.playSound(player.getLocation(), sound, volume, pitch);
+        }
+
+        public void playAt(Location location) {
+            if (location.getWorld() != null) {
+                location.getWorld().playSound(location, sound, volume, pitch);
+            }
+        }
+    }
+
+    private static class PluginSounds {
+        final Map<String, SoundEntry> sounds = new ConcurrentHashMap<>();
+        final Map<String, Map<String, SoundEntry>> moduleSounds = new ConcurrentHashMap<>();
+    }
+
+    private final YskLib lib;
+    private final Map<String, PluginSounds> pluginRegistry = new ConcurrentHashMap<>();
+
+    private SoundEntry presetSuccess;
+    private SoundEntry presetError;
+    private SoundEntry presetClick;
+    private SoundEntry presetDing;
+
+    public SoundHelper(YskLib lib) {
+        this.lib = lib;
+        loadPresets();
+        lib.getLogger().info("SoundHelper initialized");
+    }
+
+    private void loadPresets() {
+        ConfigurationSection presets = lib.getConfig().getConfigurationSection("modules.sounds.presets");
+
+        presetSuccess = parseSound(presets, "success", new SoundEntry(Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.2f));
+        presetError = parseSound(presets, "error", new SoundEntry(Sound.ENTITY_VILLAGER_NO, 1.0f, 0.8f));
+        presetClick = parseSound(presets, "click", new SoundEntry(Sound.UI_BUTTON_CLICK, 0.5f, 1.0f));
+        presetDing = parseSound(presets, "ding", new SoundEntry(Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.2f));
+    }
+
+    private SoundEntry parseSound(ConfigurationSection section, String key, SoundEntry defaultValue) {
+        if (section == null || !section.contains(key)) {
+            return defaultValue;
+        }
+
+        Object value = section.get(key);
+
+        if (value instanceof String str) {
+            return parseSoundString(str, defaultValue);
+        }
+
+        if (value instanceof ConfigurationSection cs) {
+            return parseSoundSection(cs, defaultValue);
+        }
+
+        return defaultValue;
+    }
+
+    private SoundEntry parseSoundString(String value, SoundEntry defaultValue) {
+        String[] parts = value.split(":");
+        if (parts.length < 1) {
+            return defaultValue;
+        }
+
+        try {
+            Sound sound = Sound.valueOf(parts[0].toUpperCase());
+            float volume = parts.length > 1 ? Float.parseFloat(parts[1]) : 1.0f;
+            float pitch = parts.length > 2 ? Float.parseFloat(parts[2]) : 1.0f;
+            return new SoundEntry(sound, volume, pitch);
+        } catch (IllegalArgumentException e) {
+            lib.getLogger().warning("Invalid sound in config: " + value);
+            return defaultValue;
+        }
+    }
+
+    private SoundEntry parseSoundSection(ConfigurationSection section, SoundEntry defaultValue) {
+        String soundName = section.getString("sound");
+        if (soundName == null) {
+            return defaultValue;
+        }
+
+        try {
+            Sound sound = Sound.valueOf(soundName.toUpperCase());
+            float volume = (float) section.getDouble("volume", 1.0);
+            float pitch = (float) section.getDouble("pitch", 1.0);
+            return new SoundEntry(sound, volume, pitch);
+        } catch (IllegalArgumentException e) {
+            lib.getLogger().warning("Invalid sound in config section: " + soundName);
+            return defaultValue;
+        }
+    }
+
+    public void reloadPresets() {
+        loadPresets();
+    }
+
+    private PluginSounds getOrCreatePluginSounds(String pluginName) {
+        return pluginRegistry.computeIfAbsent(pluginName, k -> new PluginSounds());
+    }
+
+    public void loadSounds(JavaPlugin plugin, ConfigurationSection soundsSection) {
+        if (soundsSection == null) return;
+
+        PluginSounds ps = getOrCreatePluginSounds(plugin.getName());
+        ps.sounds.clear();
+
+        for (String key : soundsSection.getKeys(false)) {
+            SoundEntry entry = parseSound(soundsSection, key, null);
+            if (entry != null) {
+                ps.sounds.put(key, entry);
+            }
+        }
+
+        lib.logDebug(plugin, "Loaded " + ps.sounds.size() + " sounds for " + plugin.getName());
+    }
+
+    public void loadModuleSounds(JavaPlugin plugin, String moduleName, ConfigurationSection soundsSection) {
+        if (soundsSection == null) return;
+
+        PluginSounds ps = getOrCreatePluginSounds(plugin.getName());
+        Map<String, SoundEntry> moduleMap = ps.moduleSounds.computeIfAbsent(moduleName, k -> new ConcurrentHashMap<>());
+        moduleMap.clear();
+
+        for (String key : soundsSection.getKeys(false)) {
+            SoundEntry entry = parseSound(soundsSection, key, null);
+            if (entry != null) {
+                moduleMap.put(key, entry);
+            }
+        }
+
+        lib.logDebug(plugin, "Loaded " + moduleMap.size() + " sounds for module " + moduleName);
+    }
+
+    public SoundEntry getSound(JavaPlugin plugin, String key) {
+        PluginSounds ps = pluginRegistry.get(plugin.getName());
+        return ps != null ? ps.sounds.get(key) : null;
+    }
+
+    public SoundEntry getModuleSound(JavaPlugin plugin, String moduleName, String key) {
+        PluginSounds ps = pluginRegistry.get(plugin.getName());
+        if (ps == null) return null;
+        Map<String, SoundEntry> moduleMap = ps.moduleSounds.get(moduleName);
+        return moduleMap != null ? moduleMap.get(key) : null;
+    }
+
+    public void play(JavaPlugin plugin, Player player, String key) {
+        SoundEntry entry = getSound(plugin, key);
+        if (entry != null) {
+            entry.play(player);
+        }
+    }
+
+    public void playAt(JavaPlugin plugin, Location location, String key) {
+        SoundEntry entry = getSound(plugin, key);
+        if (entry != null) {
+            entry.playAt(location);
+        }
+    }
+
+    public void playModule(JavaPlugin plugin, String moduleName, Player player, String key) {
+        SoundEntry entry = getModuleSound(plugin, moduleName, key);
+        if (entry != null) {
+            entry.play(player);
+        }
+    }
+
+    public void playModuleAt(JavaPlugin plugin, String moduleName, Location location, String key) {
+        SoundEntry entry = getModuleSound(plugin, moduleName, key);
+        if (entry != null) {
+            entry.playAt(location);
+        }
+    }
+
+    public void play(Player player, Sound sound, float volume, float pitch) {
+        player.playSound(player.getLocation(), sound, volume, pitch);
+    }
+
+    public void playAt(Location location, Sound sound, float volume, float pitch) {
+        if (location.getWorld() != null) {
+            location.getWorld().playSound(location, sound, volume, pitch);
+        }
+    }
+
+    public void playSuccess(Player player) {
+        presetSuccess.play(player);
+    }
+
+    public void playError(Player player) {
+        presetError.play(player);
+    }
+
+    public void playClick(Player player) {
+        presetClick.play(player);
+    }
+
+    public void playDing(Player player) {
+        presetDing.play(player);
+    }
+
+    public SoundEntry getPresetSuccess() {
+        return presetSuccess;
+    }
+
+    public SoundEntry getPresetError() {
+        return presetError;
+    }
+
+    public SoundEntry getPresetClick() {
+        return presetClick;
+    }
+
+    public SoundEntry getPresetDing() {
+        return presetDing;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -37,3 +37,13 @@ modules:
   
   custom-items:
     enabled: true  # Enable unified custom item manager (itemedit:<id>, internal:<id>, MATERIAL)
+
+  sounds:
+    enabled: true  # Enable SoundHelper module
+    # Preset sounds for common UI feedback
+    # Format: "SOUND_NAME:volume:pitch" or verbose YAML
+    presets:
+      success: "ENTITY_PLAYER_LEVELUP:1.0:1.2"
+      error: "ENTITY_VILLAGER_NO:1.0:0.8"
+      click: "UI_BUTTON_CLICK:0.5:1.0"
+      ding: "ENTITY_EXPERIENCE_ORB_PICKUP:1.0:1.2"


### PR DESCRIPTION
## Summary
- Add SoundHelper module for config-based sound management
- Supports compact (`SOUND:vol:pitch`) and verbose YAML config formats
- Built-in presets: success, error, click, ding (customizable in config)
- Per-plugin and per-module sound pools with caching
- Integrated into YskLib main class with config toggle

## Changes
- `src/main/java/org/yusaki/lib/modules/SoundHelper.java` - New module
- `src/main/java/org/yusaki/lib/YskLib.java` - Add field, init, getter
- `src/main/resources/config.yml` - Add sounds section with presets
- `README.md` - Add SoundHelper documentation

## Test Plan
- [ ] Build YskLib
- [ ] Start server, verify "SoundHelper initialized" in logs
- [ ] Test preset sounds work in-game